### PR TITLE
Fix path carry-through for `phylomatic_local`

### DIFF
--- a/R/phylomatic_local.R
+++ b/R/phylomatic_local.R
@@ -102,10 +102,10 @@ phylomatic_local <- function(taxa = NULL, taxauri = NULL, taxnames = TRUE,
   origpath <- getwd()
   setwd(path)
 
-  outfilepath <- file.path(path, outfile)
+  outfilepath <- file.path(outfile)
   file.create(outfilepath)
 
-  datfile <- file.path(path, basename(tempfile(fileext = ".txt")))
+  datfile <- basename(tempfile(fileext = ".txt"))
   file.create(datfile)
   cat(argstr, file = datfile)
 


### PR DESCRIPTION
## Description
A two-line fix that carries-through the path change in `phylomatic_local` so that the function doesn't cause an error when running the example. An example is given below.

## Example
```{R}
taxa <- c("Poa annua", "Phlox diffusa", "Helianthus annuus")
tree <- phylomatic_local(taxa, path = "phylomatic-ws-master")
```

Note that `phylomatic` needs to be configured properly; the symlink for `gawk` needs to be added and there is still some other kind of internal `phylomatic` error that doesn't seem to stop a tree being built (not documented in the `phylomatic` repo that I can see). I just mention this in case it's been a while since you've looked at this and you've forgotten (I would!), or I've made some kind of error (I often do!).